### PR TITLE
Improved responsiveness by adding some simple caching

### DIFF
--- a/web_omics/static/js/stores/FirdiStore.js
+++ b/web_omics/static/js/stores/FirdiStore.js
@@ -105,8 +105,10 @@ class FirdiStore extends Observable {
         // console.trace('queryResult');
 
         // get alasql query result
-        const resultset = this.sqlManager.queryDatabase(this.tablesInfo, this.constraints,
+        const mainResults = this.sqlManager.queryDatabase(this.tablesInfo, this.constraints,
             this.whereType);
+        const resultset = mainResults.queryResults;
+        const resultsetKey = mainResults.key;
 
         // get results for each table
         const fieldNames = this.fieldNames;
@@ -114,7 +116,7 @@ class FirdiStore extends Observable {
         for (let i = 0; i < fieldNames.length; i++) {
             const tableFieldNames = fieldNames[i];
             const tableName = tableFieldNames['tableName'];
-            const data = this.sqlManager.prefixQuery(tableFieldNames, resultset);
+            const data = this.sqlManager.prefixQuery(tableFieldNames, resultset, resultsetKey);
             tableData[tableName] = data;
         }
 


### PR DESCRIPTION
This helped with part 2: 'Resetting selection is slow' in issue #47 , and also improves general responsiveness when clicking around. Any previously selected results are cached now, so we don't need to run the same queries again.